### PR TITLE
Use official Docker container

### DIFF
--- a/PrimeAPL/solution_1/Dockerfile
+++ b/PrimeAPL/solution_1/Dockerfile
@@ -1,13 +1,4 @@
-FROM opensuse/leap:latest
-
-ARG DYALOG_RELEASE=18.0
-ARG DYALOG_VERSION=${DYALOG_RELEASE}.40684
-ARG BUILDTYPE=minimal
-ARG RPMFILE=https://www.dyalog.com/uploads/php/download.dyalog.com/download.php?file=${DYALOG_RELEASE}/linux_64_${DYALOG_VERSION}_unicode.x86_64.rpm
-
-ADD ${RPMFILE} /tmp/dyalog.rpm
-
-RUN zypper install --allow-unsigned-rpm -y /tmp/dyalog.rpm
+FROM dyalog/dyalog:18.0
 
 WORKDIR /opt/app
 

--- a/PrimeAPL/solution_1/bench.sh
+++ b/PrimeAPL/solution_1/bench.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cat << EOF | dyalog -b -s 2> /dev/null | grep --color=never arcfide
+cat << EOF | /opt/mdyalog/18.0/64/unicode/dyalog -b -s 2>/dev/null | grep --color=never arcfide
 )load salt
 enableSALT
 ⎕SE.SALT.Load'./PrimeSieveAPL.apln'


### PR DESCRIPTION
This should be squashed in to your PR upstream.

Changed to use the official container - having a URL to install Dyalog inside the container might give you problems if we change the URL or release another version. There's also no reason to not use the real Dyalog image for this!

J
