### PR TITLE
Remove requirement for bench.sh on Linux & docker

### DIFF
--- a/PrimeAPL/solution_1/Dockerfile
+++ b/PrimeAPL/solution_1/Dockerfile
@@ -1,8 +1,8 @@
 FROM dyalog/dyalog:18.0
 
-WORKDIR /opt/app
+WORKDIR /app
 
 COPY PrimeSieveAPL.apln .
-COPY bench.sh .
 
-ENTRYPOINT ["./bench.sh"]
+ENV LOAD=/app/PrimeSieveAPL.apln
+ENTRYPOINT ["dyalog", "-b", "-s", "2>/dev/null"]

--- a/PrimeAPL/solution_1/PrimeSieveAPL.apln
+++ b/PrimeAPL/solution_1/PrimeSieveAPL.apln
@@ -28,7 +28,7 @@
 		shy←passes
 	}
 
-	run←{warmup⍬: ⋄ i t←runOne⍬ ⋄ print i t 1}
+	Run←{warmup⍬: ⋄ i t←runOne⍬ ⋄ print i t 1}
 
 	runPar←{
 		warmup⍬:

--- a/PrimeAPL/solution_1/README.md
+++ b/PrimeAPL/solution_1/README.md
@@ -11,7 +11,7 @@ https://www.jsoftware.com/papers/50/
 
 ## Run Instructions
 
-You must have a working version of Dyalog APL installed. On Linux/UNIX, run the bench.sh script. On Windows open the .dyapp file.
+You must have a working version of Dyalog APL installed. On Linux/UNIX, run `LOAD=PrimeSieveAPL.apln dyalog`. On Windows open the .dyapp file.
 
 ## Output
 

--- a/PrimeAPL/solution_1/bench.sh
+++ b/PrimeAPL/solution_1/bench.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-cat << EOF | /opt/mdyalog/18.0/64/unicode/dyalog -b -s 2>/dev/null | grep --color=never arcfide
-)load salt
-enableSALT
-⎕SE.SALT.Load'./PrimeSieveAPL.apln'
-PrimeSieveAPL.run⍬
-⎕OFF
-EOF


### PR DESCRIPTION
Removed the bench.sh requirement!
The code now lives in /app (as per the docs for the official container), The dockerfile sets LOAD for the apln and runs dyalog with redirects.

I had to modify the .apln file to use "Run" instead of "run" otherwise I got an error on loading that "Run couldn't be found".

I also updated the README to load the apln instead rather than bench.sh.